### PR TITLE
Expose go2rtc api

### DIFF
--- a/frigate_fa/config.yaml
+++ b/frigate_fa/config.yaml
@@ -16,9 +16,11 @@ ingress_entry: /
 panel_admin: false
 ports:
   5000/tcp: null
+  1984/tcp: null
   1935/tcp: null
 ports_description:
   5000/tcp: Web interface (Not required for Hass.io Ingress)
+  1984/tcp: Go2RTC API
   1935/tcp: RTMP streams
 host_network: false
 tmpfs: true

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -16,9 +16,11 @@ ingress_entry: /
 panel_admin: false
 ports:
   5000/tcp: null
+  1984/tcp: null
   1935/tcp: null
 ports_description:
   5000/tcp: Web interface (Not required for Hass.io Ingress)
+  1984/tcp: Go2RTC API
   1935/tcp: RTMP streams
 host_network: false
 tmpfs: true


### PR DESCRIPTION
We need to expose go2rtc api so the WebRTC card can use it for exposing WebRTC in home assistant 